### PR TITLE
getting rid of mavenLocal()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,5 @@ dependencies {
 }
 repositories {
     google()
-    mavenLocal()
     jcenter()
 }

--- a/src/main/java/com/mycelium/spvmodule/IntentContract.java
+++ b/src/main/java/com/mycelium/spvmodule/IntentContract.java
@@ -192,6 +192,9 @@ public interface IntentContract {
         }
     }
 
+    /**
+     * Query the intents queue
+     */
     class WaitingIntents {
         public static final String ACTION = "com.mycelium.wallet.waitingIntents";
         public static final String RESULT_ACTION = "com.mycelium.wallet.waitingIntentsResult";


### PR DESCRIPTION
in branches of the same name, mavenLocal dependencies were turned into
gradle sub projects